### PR TITLE
This registry file is not required, and causes errors in log files if the

### DIFF
--- a/common/src/main/resources/META-INF/services/org.openrdf.rio.RDFParserFactory
+++ b/common/src/main/resources/META-INF/services/org.openrdf.rio.RDFParserFactory
@@ -1,6 +1,0 @@
-org.openrdf.rio.n3.N3ParserFactory
-org.openrdf.rio.ntriples.NTriplesParserFactory
-org.openrdf.rio.rdfxml.RDFXMLParserFactory
-org.openrdf.rio.trig.TriGParserFactory
-org.openrdf.rio.trix.TriXParserFactory
-org.openrdf.rio.turtle.TurtleParserFactory


### PR DESCRIPTION
This registry file is not required, and causes errors in log files if the full sesame package is not installed.
