### PR TITLE
Update to newly released sesame 2.5.0

### DIFF
--- a/caching/src/main/java/net/fortytwo/sesametools/caching/CachingSailConnection.java
+++ b/caching/src/main/java/net/fortytwo/sesametools/caching/CachingSailConnection.java
@@ -13,6 +13,7 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.Dataset;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.UpdateExpr;
 import org.openrdf.query.algebra.evaluation.TripleSource;
 import org.openrdf.query.algebra.evaluation.impl.EvaluationStrategyImpl;
 import org.openrdf.sail.Sail;
@@ -106,6 +107,12 @@ public class CachingSailConnection implements SailConnection {
             throw new SailException(e);
         }
     }
+
+    @Override
+	public void executeUpdate(UpdateExpr arg0, Dataset arg1, BindingSet arg2,
+			boolean arg3) throws SailException {
+    	baseSailConnection.executeUpdate(arg0, arg1, arg2, arg3);
+	}
 
     public CloseableIteration<? extends Resource, SailException> getContextIDs()
             throws SailException {

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -33,27 +33,25 @@
 
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.openrdf.sesame</groupId>
             <artifactId>sesame-sail-api</artifactId>
             <version>${sesame.version}</version>
             <type>jar</type>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.openrdf.sesame</groupId>
             <artifactId>sesame-queryalgebra-evaluation</artifactId>
             <version>${sesame.version}</version>
             <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <type>jar</type>
+            <scope>compile</scope>
         </dependency>
 
         <!-- test dependencies -->
@@ -61,6 +59,20 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.16</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+            <type>jar</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/common/src/main/java/net/fortytwo/sesametools/SingleContextSailConnection.java
+++ b/common/src/main/java/net/fortytwo/sesametools/SingleContextSailConnection.java
@@ -11,6 +11,7 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.Dataset;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.UpdateExpr;
 import org.openrdf.sail.Sail;
 import org.openrdf.sail.SailConnection;
 import org.openrdf.sail.SailException;
@@ -77,6 +78,12 @@ public class SingleContextSailConnection implements SailConnection {
 // TODO Auto-generated method stub
         return null;
     }
+
+    @Override
+	public void executeUpdate(UpdateExpr arg0, Dataset arg1, BindingSet arg2,
+			boolean arg3) throws SailException {
+    	baseSailConnection.executeUpdate(arg0, arg1, arg2, arg3);
+	}
 
     public CloseableIteration<? extends Resource, SailException> getContextIDs()
             throws SailException {

--- a/debug/src/main/java/net/fortytwo/sesametools/debug/DebugSailConnection.java
+++ b/debug/src/main/java/net/fortytwo/sesametools/debug/DebugSailConnection.java
@@ -11,6 +11,7 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.Dataset;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.UpdateExpr;
 import org.openrdf.sail.Sail;
 import org.openrdf.sail.SailConnection;
 import org.openrdf.sail.SailException;
@@ -56,6 +57,12 @@ public class DebugSailConnection implements SailConnection {
             throws SailException {
         return baseSailConnection.evaluate(tupleExpr, dataset, bindingSet, includeInferred);
     }
+
+    @Override
+	public void executeUpdate(UpdateExpr arg0, Dataset arg1, BindingSet arg2,
+			boolean arg3) throws SailException {
+    	baseSailConnection.executeUpdate(arg0, arg1, arg2, arg3);
+	}
 
     public CloseableIteration<? extends Resource, SailException> getContextIDs()
             throws SailException {

--- a/decompose/src/main/java/net/fortytwo/sesametools/decompose/DecomposeTupleQueriesSailConnection.java
+++ b/decompose/src/main/java/net/fortytwo/sesametools/decompose/DecomposeTupleQueriesSailConnection.java
@@ -12,6 +12,7 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.Dataset;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.UpdateExpr;
 import org.openrdf.query.algebra.evaluation.TripleSource;
 import org.openrdf.query.algebra.evaluation.impl.EvaluationStrategyImpl;
 import org.openrdf.sail.Sail;
@@ -70,6 +71,12 @@ public class DecomposeTupleQueriesSailConnection implements SailConnection {
             throw new SailException(e);
         }
     }
+
+    @Override
+	public void executeUpdate(UpdateExpr arg0, Dataset arg1, BindingSet arg2,
+			boolean arg3) throws SailException {
+    	baseSailConnection.executeUpdate(arg0, arg1, arg2, arg3);
+	}
 
     public CloseableIteration<? extends Resource, SailException> getContextIDs()
             throws SailException {

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,8 @@
 
     <properties>
         <sesametools.version>1.5-SNAPSHOT</sesametools.version>
-        <sesame.version>2.4.2</sesame.version>
+        <sesame.version>2.5.0</sesame.version>
+        <slf4j.version>1.6.2</slf4j.version>
         <junit.version>4.5</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/readonly/src/main/java/net/fortytwo/sesametools/readonly/ReadOnlySailConnection.java
+++ b/readonly/src/main/java/net/fortytwo/sesametools/readonly/ReadOnlySailConnection.java
@@ -11,6 +11,7 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.Dataset;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.UpdateExpr;
 import org.openrdf.sail.Sail;
 import org.openrdf.sail.SailConnection;
 import org.openrdf.sail.SailConnectionListener;
@@ -49,6 +50,12 @@ public class ReadOnlySailConnection implements SailConnection {
                                                                                        final boolean includeInferred) throws SailException {
         return baseSailConnection.evaluate(tupleExpr, dataset, bindings, includeInferred);
     }
+
+    @Override
+	public void executeUpdate(UpdateExpr arg0, Dataset arg1, BindingSet arg2,
+			boolean arg3) throws SailException {
+    	throw new SailException("Updates are not supported for this Sail");
+	}
 
     public CloseableIteration<? extends Resource, SailException> getContextIDs() throws SailException {
         return baseSailConnection.getContextIDs();

--- a/replay/src/main/java/net/fortytwo/sesametools/replay/RecorderSailConnection.java
+++ b/replay/src/main/java/net/fortytwo/sesametools/replay/RecorderSailConnection.java
@@ -25,6 +25,7 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.Dataset;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.UpdateExpr;
 import org.openrdf.sail.Sail;
 import org.openrdf.sail.SailConnection;
 import org.openrdf.sail.SailException;
@@ -97,6 +98,13 @@ public class RecorderSailConnection implements SailConnection {
         // Note: there is no EvaluateCall, nor is there a recording iterator for evaluate() results
         return baseSailConnection.evaluate(tupleExpr, dataSet, bindingSet, includeInferred);
     }
+
+    @Override
+	public void executeUpdate(UpdateExpr arg0, Dataset arg1, BindingSet arg2,
+			boolean arg3) throws SailException {
+    	// TODO: add config for this new operation
+    	baseSailConnection.executeUpdate(arg0, arg1, arg2, arg3);
+	}
 
     public CloseableIteration<? extends Resource, SailException> getContextIDs()
             throws SailException {

--- a/reposail/src/main/java/net/fortytwo/sesametools/reposail/RepositorySailConnection.java
+++ b/reposail/src/main/java/net/fortytwo/sesametools/reposail/RepositorySailConnection.java
@@ -12,6 +12,7 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.Dataset;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.UpdateExpr;
 import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
 import org.openrdf.sail.SailConnection;
@@ -85,6 +86,13 @@ public class RepositorySailConnection implements SailConnection {
         // TODO Auto-generated method stub
         return null;
     }
+
+    @Override
+	public void executeUpdate(UpdateExpr arg0, Dataset arg1, BindingSet arg2,
+			boolean arg3) throws SailException {
+    	throw new SailException("Sail to Repository updates not implemented yet");
+	}
+
 
     public CloseableIteration<? extends Resource, SailException> getContextIDs()
             throws SailException {

--- a/sesamize/pom.xml
+++ b/sesamize/pom.xml
@@ -108,6 +108,11 @@
             <version>1.0.9</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.16</version>
@@ -115,7 +120,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.1</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/writeonly/src/main/java/net/fortytwo/sesametools/writeonly/WriteOnlySailConnection.java
+++ b/writeonly/src/main/java/net/fortytwo/sesametools/writeonly/WriteOnlySailConnection.java
@@ -13,6 +13,7 @@ import org.openrdf.query.BindingSet;
 import org.openrdf.query.Dataset;
 import org.openrdf.query.QueryEvaluationException;
 import org.openrdf.query.algebra.TupleExpr;
+import org.openrdf.query.algebra.UpdateExpr;
 import org.openrdf.rio.RDFHandler;
 import org.openrdf.rio.RDFHandlerException;
 import org.openrdf.sail.SailConnection;
@@ -78,6 +79,12 @@ public class WriteOnlySailConnection implements SailConnection {
             throws SailException {
         return new EmptyCloseableIteration<BindingSet, QueryEvaluationException>();
     }
+
+    @Override
+	public void executeUpdate(UpdateExpr arg0, Dataset arg1, BindingSet arg2,
+			boolean arg3) throws SailException {
+    	throw new SailException("Updates not implemented yet for this Sail");
+	}
 
     public CloseableIteration<? extends Resource, SailException> getContextIDs()
             throws SailException {


### PR DESCRIPTION
a few changes needed for each sail to add the executeUpdate method implementations. Not all implementations are correct, but the ones that I wasn't sure about are currently going to throw SailExceptions.

also bumping slf4j to 1.6.2
