### PR TITLE
JSON-LD test changes

### DIFF
--- a/jsonld/src/test/java/net/fortytwo/sesametools/jsonld/JSONLDParserTest.java
+++ b/jsonld/src/test/java/net/fortytwo/sesametools/jsonld/JSONLDParserTest.java
@@ -1,6 +1,8 @@
 package net.fortytwo.sesametools.jsonld;
 
 import net.fortytwo.sesametools.StatementComparator;
+
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openrdf.model.Statement;
 import org.openrdf.rio.RDFParser;
@@ -33,6 +35,18 @@ public class JSONLDParserTest {
                 vf.createStatement(BNODE1, JSONLDTestConstants.FOAF.HOMEPAGE, vf.createURI("http://manu.sporny.org/")));
     }
 
+    @Test
+    public void testCoerceIRI() throws Exception {
+        g = parseToGraph("example3.json");
+    }
+    
+    @Ignore
+    @Test
+    public void testArrays() throws Exception {
+        g = parseToGraph("example4.json");
+
+    }
+        
     protected Collection<Statement> parseToGraph(final String fileName) throws Exception {
         RDFParser p = new JSONLDParser();
         StatementCollector c = new StatementCollector();

--- a/jsonld/src/test/resources/net/fortytwo/sesametools/jsonld/example1.json
+++ b/jsonld/src/test/resources/net/fortytwo/sesametools/jsonld/example1.json
@@ -1,5 +1,0 @@
-{
-  "name": "Manu Sporny",
-  "homepage": "http://manu.sporny.org/",
-  "avatar": "http://twitter.com/account/profile_image/manusporny"
-}

--- a/jsonld/src/test/resources/net/fortytwo/sesametools/jsonld/example3.json
+++ b/jsonld/src/test/resources/net/fortytwo/sesametools/jsonld/example3.json
@@ -3,8 +3,8 @@
     "Book":         "http://example.org/vocab#Book",
     "Chapter":      "http://example.org/vocab#Chapter",
     "contains":     "http://example.org/vocab#contains",
-    "creator":      "http://purl.org/dc/terms/creator"
-    "description":  "http://purl.org/dc/terms/description"
+    "creator":      "http://purl.org/dc/terms/creator" ,
+    "description":  "http://purl.org/dc/terms/description" ,
     "Library":      "http://example.org/vocab#Library",
     "title":        "http://purl.org/dc/terms/title",
     "@coerce":

--- a/jsonld/src/test/resources/net/fortytwo/sesametools/jsonld/example4.json
+++ b/jsonld/src/test/resources/net/fortytwo/sesametools/jsonld/example4.json
@@ -1,0 +1,32 @@
+[{
+    "@subject": {
+        "@iri": "http://example.com/library"
+    },
+    "http://example.org/vocab#contains": {
+        "@iri": "http://example.org/library/the-republic"
+    },
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+        "@iri": "http://example.org/vocab#Library"
+    }
+}, {
+    "@subject": {
+        "@iri": "http://example.org/library/the-republic"
+    },
+    "http://example.org/vocab#contains": {
+        "@iri": "http://example.org/library/the-republic#introduction"
+    },
+    "http://purl.org/dc/terms/creator": "Plato",
+    "http://purl.org/dc/terms/title": "The Republic",
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+        "@iri": "http://example.org/vocab#Book"
+    }
+}, {
+    "@subject": {
+        "@iri": "http://example.org/library/the-republic#introduction"
+    },
+    "http://purl.org/dc/terms/description": "An introductory chapter on The Republic.",
+    "http://purl.org/dc/terms/title": "The Introduction",
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+        "@iri": "http://example.org/vocab#Chapter"
+    }
+}]


### PR DESCRIPTION
Fix JSON syntax in example3.json so that it parses as both JSON and JSON-LD

Add a new failing test, example4.json, for multiple contexts in a single graph, per the JSON-LD specification appendix A.1

Remove example1.json as it is no longer valid JSON-LD, even if it does still appear on their website. 
