### PR TITLE
Converted RdfListUtil to a non-static class

### DIFF
--- a/common/src/main/java/net/fortytwo/sesametools/RdfListUtil.java
+++ b/common/src/main/java/net/fortytwo/sesametools/RdfListUtil.java
@@ -33,6 +33,21 @@ public class RdfListUtil {
             .getLogger(RdfListUtil.class);
 
     /**
+     * The default value for checkCycles if no other value is given.
+     */
+    public final static boolean DEFAULT_CHECK_CYCLES = true;
+
+    /**
+     * The default value for checkIncomplete if no other value is given.
+     */
+	public final static boolean DEFAULT_CHECK_INCOMPLETE = true;
+
+    /**
+     * The default value for useIterativeOnError if no other value is given.
+     */
+	public final static boolean DEFAULT_USE_ITERATIVE_ON_ERROR = true;
+
+    /**
      * If enabled, this causes the getLists method to throw RuntimeExceptions if cyclic lists are found.
      * 
      * Disabling this property should not cause infinite loops, as otherwise simple cyclic loops would always cause OutOfMemoryExceptions or StackOverflowExceptions.
@@ -40,8 +55,10 @@ public class RdfListUtil {
      * Disabling this property may result in missing lists from results.
      * 
      * NOTE: Tests will fail if you disable this property.
+     * 
+     * Defaults to the constant defined in RdfListUtil.DEFAULT_CHECK_CYCLES
      */
-    private static boolean CHECK_CYCLES = true;
+    private final boolean checkCycles;
 
     /**
      * If enabled, this causes the getLists method to throw RuntimeExceptions when incomplete or invalid lists are found.
@@ -49,7 +66,7 @@ public class RdfListUtil {
      * Some of the cases checked include:
      * 
      * <ul>
-     * 	<li>whether RDF.REST predicates all map to Resource Objects</li>
+     *  <li>whether RDF.REST predicates all map to Resource Objects</li>
      *  <li>whether all of the given heads are Resources</li>
      *  <li>whether RDF.REST predicates map to Resource objects that contain both RDF.FIRST and valid RDF.REST statements</li>
      * </ul>
@@ -57,14 +74,49 @@ public class RdfListUtil {
      * Disabling this check may cause unexpected results, including incomplete and missing lists.
      * 
      * NOTE: Tests will fail if you disable this property.
+     * 
+     * Defaults to the constant defined in RdfListUtil.DEFAULT_CHECK_INCOMPLETE
      */
-	private static boolean CHECK_INCOMPLETE = true;
+    private final boolean checkIncomplete;
 
+    /**
+     * If enabled, this causes the getLists method to switch from the recursive 
+     * method to the iterative method when the hardcoded recursion limit is 
+     * reached for a list.
+     * 
+     * The iterative approach is slower in general than the recursive approach, 
+     * but can handle much deeper and wider lists.
+     * 
+     * Defaults to the constant defined in RdfListUtil.DEFAULT_USE_ITERATIVE_ON_ERROR
+     */
+    private final boolean useIterativeOnError;
+
+    /**
+     * Constructs an instance of the RDF List Processing Utility using the 
+     * default error checking and redundancy values.
+     */
+	public RdfListUtil() {
+	    this(DEFAULT_CHECK_CYCLES, DEFAULT_CHECK_INCOMPLETE, DEFAULT_USE_ITERATIVE_ON_ERROR);
+	}
+	
 	/**
-	 * If enabled, this causes the getLists method to switch from the recursive method to the iterative method when the hardcoded recursion limit is reached for a list.
+	 * Constructs an instance of the RDF List Processing Utility using the 
+	 * given values to define operational checking and redundancy parameters.
+	 * 
+	 * @param checkCycles 
+	 *         Defines whether to check for cycles in lists.
+	 * @param checkIncomplete 
+	 *         Defines whether to check for properly ended lists.
+	 * @param useIterativeOnError 
+	 *         Defines whether to use iterative approach when recursive 
+	 *         approach fails with out of memory or stack overflow.
 	 */
-	private static boolean USE_RECURSIVE_ON_ERROR = true;
-
+	public RdfListUtil(boolean checkCycles, boolean checkIncomplete, boolean useIterativeOnError) {
+        this.checkCycles = checkCycles;
+        this.checkIncomplete = checkIncomplete;
+        this.useIterativeOnError = useIterativeOnError;
+	}
+	
     /**
      * Adds an RDF List with the given elements to a graph.
      *
@@ -76,7 +128,7 @@ public class RdfListUtil {
      *                     contexts are given, statements will be added to the default
      *                     (null) context.
      */
-    public static void addList(final Resource head,
+    public void addList(final Resource head,
                                final List<Value> nextValues, final Graph graphToAddTo,
                                final Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
@@ -121,7 +173,7 @@ public class RdfListUtil {
      *                     contexts are given, statements will be added to the default
      *                     (null) context.
      */
-    public static void addListAtNode(final Resource subject,
+    public void addListAtNode(final Resource subject,
                                      final URI predicate, final List<Value> nextValues,
                                      final Graph graphToAddTo, final Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
@@ -134,7 +186,7 @@ public class RdfListUtil {
             graphToAddTo.add(subject, predicate, aHead, contexts);
         }
 
-        RdfListUtil.addList(aHead, nextValues, graphToAddTo, contexts);
+        this.addList(aHead, nextValues, graphToAddTo, contexts);
     }
 
     /**
@@ -145,11 +197,11 @@ public class RdfListUtil {
      * @param contexts      the graph contexts from which the list is to be fetched
      * @return the contents of the list
      */
-    public static List<Value> getList(final Resource head,
+    public List<Value> getList(final Resource head,
                                       final Graph graphToSearch, final Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
 
-        final Collection<List<Value>> results = RdfListUtil.getLists(Collections.singleton(head),
+        final Collection<List<Value>> results = this.getLists(Collections.singleton(head),
                 graphToSearch, contexts);
 
         if (results.size() > 1) {
@@ -181,12 +233,12 @@ public class RdfListUtil {
      * @return the contents of the list
      * @throws RuntimeException if the list structure was not complete, or it had cycles
      */
-    public static List<Value> getListAtNode(final Resource subject,
+    public List<Value> getListAtNode(final Resource subject,
                                             final URI predicate, final Graph graphToSearch,
                                             final Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
 
-        final Collection<List<Value>> allLists = RdfListUtil.getListsAtNode(
+        final Collection<List<Value>> allLists = this.getListsAtNode(
                 subject, predicate, graphToSearch, contexts);
 
         if (allLists.size() > 1) {
@@ -213,7 +265,7 @@ public class RdfListUtil {
      *         collection is returned.
      */
     //*
-    public static Collection<List<Value>> getListsIterative(final Set<Resource> heads,
+    public Collection<List<Value>> getListsIterative(final Set<Resource> heads,
                                                    final Graph graphToSearch, final Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
 
@@ -245,7 +297,7 @@ public class RdfListUtil {
     //*/
 
     //*
-    public static Collection<List<Value>> getLists(final Set<Resource> heads,
+    public Collection<List<Value>> getLists(final Set<Resource> heads,
                                                    final Graph graphToSearch,
                                                    final Resource... contexts) {
         Collection<List<Value>> matches = new LinkedList<List<Value>>();
@@ -258,7 +310,7 @@ public class RdfListUtil {
         }
     	catch(RuntimeException rex)
     	{
-    		if(USE_RECURSIVE_ON_ERROR && rex.getMessage().contains("List was too long"))
+    		if(this.getUseIterativeOnError() && rex.getMessage().contains("List was too long"))
     		{
     			matches.clear();
     			matches = getListsIterative(heads, graphToSearch, contexts);
@@ -273,7 +325,7 @@ public class RdfListUtil {
     }
     //*/
 
-    public static Collection<List<Value>> getListsRecursive(final Resource head,
+    public Collection<List<Value>> getListsRecursive(final Resource head,
                                                    final Graph graph,
                                                    final Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
@@ -293,7 +345,7 @@ public class RdfListUtil {
         return matches;
     }
 
-    private static void matchLists(final Resource head,
+    private void matchLists(final Resource head,
                                    final Graph graph,
                                    final Collection<List<Value>> matches,
                                    final Set<Resource> prev,
@@ -306,14 +358,14 @@ public class RdfListUtil {
                 finalisedList.add(j, buffer[j]);
             }
             matches.add(finalisedList);
-        } else if(CHECK_INCOMPLETE && !(head instanceof Resource)) {
+        } else if(this.getCheckIncomplete() && !(head instanceof Resource)) {
         	throw new RuntimeException("List structure was not complete");
         } else if (!prev.contains(head)) {  // List continues, no cycle so far.
             prev.add(head);
 
             Iterator<Statement> first = graph.match(head, RDF.FIRST, null, contexts);
             
-            if(CHECK_INCOMPLETE && !first.hasNext()) {
+            if(this.getCheckIncomplete() && !first.hasNext()) {
             	throw new RuntimeException("List structure was not complete");
             }
             
@@ -322,7 +374,7 @@ public class RdfListUtil {
 
                 Iterator<Statement> rest = graph.match(head, RDF.REST, null, contexts);
 
-                if(CHECK_INCOMPLETE && !rest.hasNext()) {
+                if(this.getCheckIncomplete() && !rest.hasNext()) {
                 	throw new RuntimeException("List structure was not complete");
                 }
                 
@@ -334,22 +386,22 @@ public class RdfListUtil {
                     		throw new RuntimeException(String.format("List was too long, maximum is %d elements long", buffer.length));
                     	}
                         matchLists((Resource) r, graph, matches, prev, buffer, i + 1);
-	                } else if(CHECK_INCOMPLETE) {
+	                } else if(this.getCheckIncomplete()) {
 	                	throw new RuntimeException("List structure was not complete");
 	                }
                 }
             }
 
             prev.remove(head);
-        } else if(prev.contains(head) && CHECK_CYCLES) {
+        } else if(prev.contains(head) && this.getCheckCycles()) {
         	throw new RuntimeException("List cannot contain cycles");
-        } else if(CHECK_INCOMPLETE) {
+        } else if(this.getCheckIncomplete()) {
         	throw new RuntimeException("List structure was not complete");
         }
         
     }
 
-    private static List<List<Value>> getValuesForPointerTrails(
+    private List<List<Value>> getValuesForPointerTrails(
             final Graph graphToSearch,
             List<List<Resource>> completedPointerTrails,
             final Resource... contexts) {
@@ -416,7 +468,7 @@ public class RdfListUtil {
         return results;
     }
 
-    private static void followPointerTrails(Resource nextHead,
+    private void followPointerTrails(Resource nextHead,
                                             Graph graphToSearch, List<List<Resource>> completedPointerTrails,
                                             Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
@@ -484,7 +536,7 @@ public class RdfListUtil {
         } while (!allDone);
     }
 
-    private static boolean resolveNextMatch(
+    private boolean resolveNextMatch(
             List<List<Resource>> completedPointerTrails,
             List<Resource> currentPointerTrail,
             List<List<Resource>> uncompletedPointerTrails, boolean allDone,
@@ -496,7 +548,7 @@ public class RdfListUtil {
         if (nextValue instanceof Resource) {
             Resource nextResource = (Resource) nextValue;
 
-            if (CHECK_CYCLES && currentPointerTrail.contains(nextResource)) {
+            if (this.getCheckCycles() && currentPointerTrail.contains(nextResource)) {
                 throw new RuntimeException("List cannot contain cycles");
             }
 
@@ -531,7 +583,7 @@ public class RdfListUtil {
      * @return all matching lists. If no matching lists are found, an empty
      *         collection is returned.
      */
-    public static Collection<List<Value>> getListsAtNode(
+    public Collection<List<Value>> getListsAtNode(
             final Resource subject, final URI predicate,
             final Graph graphToSearch, final Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
@@ -551,14 +603,36 @@ public class RdfListUtil {
             }
         }
 
-        results = RdfListUtil.getLists(heads, graphToSearch, contexts);
+        results = this.getLists(heads, graphToSearch, contexts);
 
         return results;
     }
 
     /**
-     *
+     * @return True if this utility is setup to check for cycles and throw 
+     *          exceptions if it finds cycles in lists.
      */
-    private RdfListUtil() {
+    public boolean getCheckCycles()
+    {
+        return checkCycles;
     }
+
+    /**
+     * @return True if this utility is setup to check for incomplete, 
+     *          unterminated lists, and throw exceptions if it finds any.
+     */
+    public boolean getCheckIncomplete()
+    {
+        return checkIncomplete;
+    }
+
+    /** 
+     * @return True if this utility is setup to use a slower iterative approach
+     *          then a recursive approach fails.
+     */
+    public boolean getUseIterativeOnError()
+    {
+        return useIterativeOnError;
+    }
+
 }

--- a/common/src/test/java/net/fortytwo/sesametools/RdfListUtilTest.java
+++ b/common/src/test/java/net/fortytwo/sesametools/RdfListUtilTest.java
@@ -41,6 +41,10 @@ public class RdfListUtilTest
 {
     private static final Logger log = LoggerFactory.getLogger(RdfListUtilTest.class);
 
+    private RdfListUtil testRdfListUtilDefaults;
+    private RdfListUtil testRdfListUtilNoChecks;
+    private RdfListUtil testRdfListUtilNoChecksOrRecursion;
+    
     private Graph testGraph;
     private ValueFactory vf;
     
@@ -61,10 +65,14 @@ public class RdfListUtilTest
     private BNode testListHeadBNode2;
 
 	private Value testObjectLiteral2;
-    
+
     @Before
     public void setUp()
     {
+        this.testRdfListUtilDefaults = new RdfListUtil();
+        this.testRdfListUtilNoChecks = new RdfListUtil(false, false, true);
+        this.testRdfListUtilNoChecksOrRecursion = new RdfListUtil(false, false, false);
+        
         this.testGraph = new GraphImpl();
         this.vf = this.testGraph.getValueFactory();
         
@@ -97,6 +105,10 @@ public class RdfListUtilTest
     @After
     public void tearDown()
     {
+        this.testRdfListUtilDefaults = null;
+        this.testRdfListUtilNoChecks = null;
+        this.testRdfListUtilNoChecksOrRecursion = null;
+        
         this.testGraph = null;
         this.vf = null;
         
@@ -128,7 +140,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListAtNodeEmptyNoContext()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesEmpty, this.testGraph);
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesEmpty, this.testGraph);
         
         Assert.assertEquals(0, this.testGraph.size());
     }
@@ -141,7 +153,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListAtNodeMultipleElementsNoContext()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesMultipleElements,
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesMultipleElements,
                 this.testGraph);
         
         Assert.assertEquals(7, this.testGraph.size());
@@ -261,7 +273,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListAtNodeSingleElementNoContext()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesSingleUri,
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesSingleUri,
                 this.testGraph);
         
         Assert.assertEquals(3, this.testGraph.size());
@@ -321,7 +333,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListBNodeHeadEmptyNoContext()
     {
-        RdfListUtil.addList(this.testListHeadBNode1, this.testValuesEmpty, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadBNode1, this.testValuesEmpty, this.testGraph);
         
         Assert.assertEquals(0, this.testGraph.size());
     }
@@ -334,7 +346,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListBNodeHeadMultipleElementsNoContext()
     {
-        RdfListUtil.addList(this.testListHeadBNode1, this.testValuesMultipleElements, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadBNode1, this.testValuesMultipleElements, this.testGraph);
         
         Assert.assertEquals(6, this.testGraph.size());
         
@@ -439,7 +451,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListBNodeHeadSingleElementNoContext()
     {
-        RdfListUtil.addList(this.testListHeadBNode1, this.testValuesSingleUri, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadBNode1, this.testValuesSingleUri, this.testGraph);
         
         Assert.assertEquals(2, this.testGraph.size());
         
@@ -483,7 +495,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListUriHeadEmptyNoContext()
     {
-        RdfListUtil.addList(this.testListHeadUri1, this.testValuesEmpty, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadUri1, this.testValuesEmpty, this.testGraph);
         
         Assert.assertEquals(0, this.testGraph.size());
     }
@@ -496,7 +508,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListURIHeadMultipleElementsNoContext()
     {
-        RdfListUtil.addList(this.testListHeadUri1, this.testValuesMultipleElements, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadUri1, this.testValuesMultipleElements, this.testGraph);
         
         Assert.assertEquals(6, this.testGraph.size());
         
@@ -601,7 +613,7 @@ public class RdfListUtilTest
     @Test
     public void testAddListURIHeadSingleElementNoContext()
     {
-        RdfListUtil.addList(this.testListHeadUri1, this.testValuesSingleUri, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadUri1, this.testValuesSingleUri, this.testGraph);
         
         Assert.assertEquals(2, this.testGraph.size());
         
@@ -645,7 +657,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListAfterAddListAtNodeMultipleElementsNullContext()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesMultipleElements,
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesMultipleElements,
                 this.testGraph);
         
         Assert.assertEquals(7, this.testGraph.size());
@@ -665,7 +677,7 @@ public class RdfListUtilTest
         Assert.assertTrue(matchedStatement.getObject() instanceof Resource);
         
         final List<Value> results =
-                RdfListUtil.getList((BNode)matchedStatement.getObject(), this.testGraph, (Resource)null);
+                this.testRdfListUtilDefaults.getList((BNode)matchedStatement.getObject(), this.testGraph, (Resource)null);
         
         Assert.assertEquals(3, results.size());
         
@@ -683,7 +695,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListAtNodeAfterInvalidGraphOperation()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesMultipleElements,
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesMultipleElements,
                 this.testGraph);
         
         Assert.assertEquals(7, this.testGraph.size());
@@ -705,7 +717,7 @@ public class RdfListUtilTest
         {
             @SuppressWarnings("unused")
             final List<Value> results =
-                    RdfListUtil.getListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testGraph,
+                    this.testRdfListUtilDefaults.getListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testGraph,
                             (Resource)null);
             
             Assert.assertEquals("Returned results from an invalid list structure", 0, results.size());
@@ -725,13 +737,13 @@ public class RdfListUtilTest
     @Test
     public void testGetListAtNodeMultipleElementsNullContext()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesMultipleElements,
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesMultipleElements,
                 this.testGraph);
         
         Assert.assertEquals(7, this.testGraph.size());
         
         final List<Value> results =
-                RdfListUtil.getListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testGraph, (Resource)null);
+                this.testRdfListUtilDefaults.getListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testGraph, (Resource)null);
         
         Assert.assertEquals(3, results.size());
         
@@ -749,7 +761,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListBNodeHeadAfterInvalidGraphOperation()
     {
-        RdfListUtil.addList(this.testListHeadBNode1, this.testValuesMultipleElements, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadBNode1, this.testValuesMultipleElements, this.testGraph);
         
         Assert.assertEquals(6, this.testGraph.size());
         
@@ -769,7 +781,7 @@ public class RdfListUtilTest
         try
         {
             @SuppressWarnings("unused")
-            final List<Value> results = RdfListUtil.getList(this.testListHeadBNode1, this.testGraph, (Resource)null);
+            final List<Value> results = this.testRdfListUtilDefaults.getList(this.testListHeadBNode1, this.testGraph, (Resource)null);
 
             Assert.assertEquals("Returned results from an invalid list structure", 0, results.size());
             Assert.fail("Did not find expected exception");
@@ -788,7 +800,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListBNodeHeadAfterInvalidGraphOperation2()
     {
-        RdfListUtil.addList(this.testListHeadBNode1, this.testValuesMultipleElements, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadBNode1, this.testValuesMultipleElements, this.testGraph);
         
         Assert.assertEquals(6, this.testGraph.size());
         
@@ -812,7 +824,7 @@ public class RdfListUtilTest
         try
         {
             @SuppressWarnings("unused")
-            final List<Value> results = RdfListUtil.getList(this.testListHeadBNode1, this.testGraph, (Resource)null);
+            final List<Value> results = this.testRdfListUtilDefaults.getList(this.testListHeadBNode1, this.testGraph, (Resource)null);
 
             Assert.assertEquals("Returned results from an invalid list structure", 0, results.size());
             Assert.fail("Did not find expected exception");
@@ -831,11 +843,11 @@ public class RdfListUtilTest
     @Test
     public void testGetListBNodeHeadMultipleElementsNullContext()
     {
-        RdfListUtil.addList(this.testListHeadBNode1, this.testValuesMultipleElements, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadBNode1, this.testValuesMultipleElements, this.testGraph);
         
         Assert.assertEquals(6, this.testGraph.size());
         
-        final List<Value> results = RdfListUtil.getList(this.testListHeadBNode1, this.testGraph, (Resource)null);
+        final List<Value> results = this.testRdfListUtilDefaults.getList(this.testListHeadBNode1, this.testGraph, (Resource)null);
         
         Assert.assertEquals(3, results.size());
         
@@ -848,7 +860,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListsAtNodeSingleNullContext()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesSingleUri,
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesSingleUri,
                 this.testGraph);
         
         Assert.assertEquals(3, this.testGraph.size());
@@ -867,7 +879,7 @@ public class RdfListUtilTest
         Assert.assertTrue(matchedStatement.getObject() instanceof Resource);
         
         final Collection<List<Value>> lists =
-                RdfListUtil
+                this.testRdfListUtilDefaults
                         .getListsAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testGraph, (Resource)null);
         
         Assert.assertEquals(1, lists.size());
@@ -884,7 +896,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListsAfterAddListAtNodeSingleNullContext()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesSingleUri,
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesSingleUri,
                 this.testGraph);
         
         Assert.assertEquals(3, this.testGraph.size());
@@ -906,7 +918,7 @@ public class RdfListUtilTest
         heads.add((BNode)matchedStatement.getObject());
         
         final Collection<List<Value>> lists =
-                RdfListUtil
+                this.testRdfListUtilDefaults
                         .getLists(heads, this.testGraph, (Resource)null);
         
         Assert.assertEquals(1, lists.size());
@@ -923,7 +935,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListsAfterAddListBNodeHeadSingleNullContext()
     {
-        RdfListUtil.addList(this.testListHeadBNode1, this.testValuesSingleUri,
+        this.testRdfListUtilDefaults.addList(this.testListHeadBNode1, this.testValuesSingleUri,
                 this.testGraph);
         
         Assert.assertEquals(2, this.testGraph.size());
@@ -943,7 +955,7 @@ public class RdfListUtilTest
         heads.add((BNode)matchedStatement.getSubject());
         
         final Collection<List<Value>> lists =
-                RdfListUtil
+                this.testRdfListUtilDefaults
                         .getLists(heads, this.testGraph);
         
         Assert.assertEquals(1, lists.size());
@@ -960,7 +972,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListsSingleNullContext()
     {
-        RdfListUtil.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesSingleUri,
+        this.testRdfListUtilDefaults.addListAtNode(this.testSubjectUri1, this.testPredicateUri1, this.testValuesSingleUri,
                 this.testGraph);
         
         Assert.assertEquals(3, this.testGraph.size());
@@ -984,7 +996,7 @@ public class RdfListUtilTest
         
         heads.add(headNode);
         
-        final Collection<List<Value>> lists = RdfListUtil.getLists(heads, this.testGraph);
+        final Collection<List<Value>> lists = this.testRdfListUtilDefaults.getLists(heads, this.testGraph);
         
         Assert.assertEquals(1, lists.size());
         
@@ -1005,7 +1017,7 @@ public class RdfListUtilTest
     @Test
     public void testGetListURIHeadAfterInvalidGraphOperation()
     {
-        RdfListUtil.addList(this.testListHeadUri1, this.testValuesMultipleElements, this.testGraph);
+        this.testRdfListUtilDefaults.addList(this.testListHeadUri1, this.testValuesMultipleElements, this.testGraph);
         
         Assert.assertEquals(6, this.testGraph.size());
         
@@ -1025,7 +1037,7 @@ public class RdfListUtilTest
         try
         {
             @SuppressWarnings("unused")
-            final List<Value> results = RdfListUtil.getList(this.testListHeadUri1, this.testGraph, (Resource)null);
+            final List<Value> results = this.testRdfListUtilDefaults.getList(this.testListHeadUri1, this.testGraph, (Resource)null);
 
             Assert.assertEquals("Returned results from an invalid list structure", 0, results.size());
             Assert.fail("Did not find expected exception");
@@ -1069,7 +1081,7 @@ public class RdfListUtilTest
         Set<Resource> heads = new HashSet<Resource>(1);
         heads.add(this.testListHeadBNode1);
         
-        final Collection<List<Value>> results = RdfListUtil.getLists(heads, this.testGraph);
+        final Collection<List<Value>> results = this.testRdfListUtilDefaults.getLists(heads, this.testGraph);
 
         Assert.assertEquals(2, results.size());
         
@@ -1139,7 +1151,7 @@ public class RdfListUtilTest
         Assert.assertEquals(expectedGraphCount, this.testGraph.size());
         
         log.info("start");
-        final Collection<List<Value>> results = RdfListUtil.getLists(heads, this.testGraph);
+        final Collection<List<Value>> results = this.testRdfListUtilDefaults.getLists(heads, this.testGraph);
         log.info("end");
 
         int expectedResultsCount = iCount;
@@ -1195,7 +1207,7 @@ public class RdfListUtilTest
         Assert.assertEquals(expectedGraphCount, this.testGraph.size());
         
         log.info("start");
-        final Collection<List<Value>> results = RdfListUtil.getLists(heads, this.testGraph);
+        final Collection<List<Value>> results = this.testRdfListUtilDefaults.getLists(heads, this.testGraph);
         log.info("end");
 
         int expectedResultsCount = iCount;
@@ -1273,7 +1285,7 @@ public class RdfListUtilTest
         Assert.assertEquals(expectedGraphCount, this.testGraph.size());
         
         log.info("start");
-        final Collection<List<Value>> results = RdfListUtil.getLists(heads, this.testGraph);
+        final Collection<List<Value>> results = this.testRdfListUtilDefaults.getLists(heads, this.testGraph);
         log.info("end");
         
         int expectedResultsCount = (
@@ -1405,7 +1417,144 @@ public class RdfListUtilTest
         Assert.assertEquals(expectedGraphCount, this.testGraph.size());
         
         log.info("start");
-        final Collection<List<Value>> results = RdfListUtil.getLists(heads, this.testGraph);
+        final Collection<List<Value>> results = this.testRdfListUtilDefaults.getLists(heads, this.testGraph);
+        log.info("end");
+        
+        int expectedResultsCount = (
+                // one variable length branch for each i for each k
+                (iHeadCount*kDepthCount)
+                // one longest branch for each i
+                +iHeadCount
+                // one variable length branch for each m for each n
+                + (mHeadCount*nDepthCount)
+                // one longest branch for each m
+                +mHeadCount
+                );
+        log.info("expectedResultsCount="+expectedResultsCount);
+        log.info("results.size()="+results.size());
+        
+        Assert.assertEquals(expectedResultsCount, results.size());
+        
+    }
+
+    /**
+     * Tests a mix of shallow and deep lists in the same getLists call without checking for errors
+     */
+    @Test
+    public void testGetListsForkedValidStressDeepAndShallowNoErrorChecking()
+    {
+        Set<Resource> heads = new HashSet<Resource>();
+
+        int iHeadCount = 500;
+        int kDepthCount = 4;
+        
+        int mHeadCount = 4;
+        int nDepthCount = 50;
+        
+        for(int i = 0; i < iHeadCount; i++)
+        {
+            BNode nextHeadBNode = vf.createBNode("i-"+i);
+            BNode nextRestBNode = nextHeadBNode;
+            
+            for(int k = 0; k < kDepthCount; k++)
+            {
+                BNode nextTreeBNode1 = vf.createBNode("i-"+i+"_k-"+k+"_a");
+                BNode nextTreeBNode2 = vf.createBNode("i-"+i+"_k-"+k+"_b");
+                
+                Statement nextTestStatement1 = vf.createStatement(nextRestBNode, RDF.FIRST, vf.createLiteral("literal: i-"+i+"_k-"+k));
+                this.testGraph.add(nextTestStatement1);
+                
+                // Fork the list in two
+                Statement nextTestStatement2 = vf.createStatement(nextRestBNode, RDF.REST, nextTreeBNode1);
+                this.testGraph.add(nextTestStatement2);
+                Statement nextTestStatement3 = vf.createStatement(nextRestBNode, RDF.REST, nextTreeBNode2);
+                this.testGraph.add(nextTestStatement3);
+
+                // Generate a terminating element for one of the arms
+                Statement nextTestNilStatement1 = vf.createStatement(nextTreeBNode2, RDF.FIRST, vf.createLiteral("terminating i-"+i+"_k-"+k+"_b"));
+                this.testGraph.add(nextTestNilStatement1);
+                
+                Statement nextTestNilStatement2 = vf.createStatement(nextTreeBNode2, RDF.REST, RDF.NIL);
+                this.testGraph.add(nextTestNilStatement2);
+            
+                if(k == kDepthCount-1)
+                {
+                    Statement nextTestNilStatement3 = vf.createStatement(nextTreeBNode1, RDF.FIRST, vf.createLiteral("terminating i-"+i+"_k-"+k+"_a"));
+                    this.testGraph.add(nextTestNilStatement3);
+                    
+                    Statement nextTestNilStatement4 = vf.createStatement(nextTreeBNode1, RDF.REST, RDF.NIL);
+                    this.testGraph.add(nextTestNilStatement4);
+                }
+                else
+                {
+                    // branch others off the first one
+                    nextRestBNode = nextTreeBNode1;
+                }                    
+            }
+            heads.add(nextHeadBNode);
+        }
+        
+        
+        
+        for(int m = 0; m < mHeadCount; m++)
+        {
+            BNode nextHeadBNode = vf.createBNode("m-"+m);
+            BNode nextRestBNode = nextHeadBNode;
+            
+            for(int n = 0; n < nDepthCount; n++)
+            {
+                BNode nextTreeBNode1 = vf.createBNode("m-"+m+"_n-"+n+"_a");
+                BNode nextTreeBNode2 = vf.createBNode("m-"+m+"_n-"+n+"_b");
+                
+                Statement nextTestStatement1 = vf.createStatement(nextRestBNode, RDF.FIRST, vf.createLiteral("literal: m-"+m+"_n-"+n));
+                this.testGraph.add(nextTestStatement1);
+                
+                // Fork the list in two
+                Statement nextTestStatement2 = vf.createStatement(nextRestBNode, RDF.REST, nextTreeBNode1);
+                this.testGraph.add(nextTestStatement2);
+                Statement nextTestStatement3 = vf.createStatement(nextRestBNode, RDF.REST, nextTreeBNode2);
+                this.testGraph.add(nextTestStatement3);
+
+                // Generate a terminating element for one of the arms
+                Statement nextTestNilStatement1 = vf.createStatement(nextTreeBNode2, RDF.FIRST, vf.createLiteral("terminating m-"+m+"_n-"+n+"_b"));
+                this.testGraph.add(nextTestNilStatement1);
+                
+                Statement nextTestNilStatement2 = vf.createStatement(nextTreeBNode2, RDF.REST, RDF.NIL);
+                this.testGraph.add(nextTestNilStatement2);
+            
+                if(n == nDepthCount-1)
+                {
+                    Statement nextTestNilStatement3 = vf.createStatement(nextTreeBNode1, RDF.FIRST, vf.createLiteral("terminating m-"+m+"_n-"+n+"_a"));
+                    this.testGraph.add(nextTestNilStatement3);
+                    
+                    Statement nextTestNilStatement4 = vf.createStatement(nextTreeBNode1, RDF.REST, RDF.NIL);
+                    this.testGraph.add(nextTestNilStatement4);
+                }
+                else
+                {
+                    // branch others off the first one
+                    nextRestBNode = nextTreeBNode1;
+                }                    
+            }
+            heads.add(nextHeadBNode);
+        }
+        
+        int expectedGraphCount = (
+                // 5 statements for each i for each k
+                (iHeadCount*kDepthCount*5)+
+                // 2 terminating statements for each i
+                        (iHeadCount*2)+
+                // 5 statements for each m for each n
+                (mHeadCount*nDepthCount*5)+
+                // 2 terminating statements for each m
+                        (mHeadCount*2)
+                );
+        log.info("expectedGraphCount="+expectedGraphCount);
+        log.info("this.testGraph.size()="+this.testGraph.size());
+        Assert.assertEquals(expectedGraphCount, this.testGraph.size());
+        
+        log.info("start");
+        final Collection<List<Value>> results = this.testRdfListUtilNoChecks.getLists(heads, this.testGraph);
         log.info("end");
         
         int expectedResultsCount = (
@@ -1497,7 +1646,7 @@ public class RdfListUtilTest
         Assert.assertEquals(expectedGraphCount, this.testGraph.size());
         
         log.info("start");
-        final Collection<List<Value>> results = RdfListUtil.getLists(heads, this.testGraph);
+        final Collection<List<Value>> results = this.testRdfListUtilDefaults.getLists(heads, this.testGraph);
         log.info("end");
         
         int expectedResultsCount = (
@@ -1510,6 +1659,88 @@ public class RdfListUtilTest
         
         Assert.assertEquals(expectedResultsCount, results.size());
         
+    }
+
+    /**
+     * This test goes past the default 1000 stack frame boundary for the 
+     * recursive implementation and then fails as we have told the utility in 
+     * this case not to use the iterative implementation as a backup.
+     */
+    @Test
+    public void testGetListsForkedValidStressDeepNoIterative()
+    {
+        int iCount = 5;
+        int kCount = 1100;
+        
+        Set<Resource> heads = new HashSet<Resource>((int)(iCount*1.5));
+        
+        for(int i = 0; i < iCount; i++)
+        {
+            BNode nextHeadBNode = vf.createBNode("i-"+i);
+            BNode nextRestBNode = nextHeadBNode;
+            
+            for(int k = 0; k < kCount; k++)
+            {
+                BNode nextTreeBNode1 = vf.createBNode("i-"+i+"_k-"+k+"_a");
+                BNode nextTreeBNode2 = vf.createBNode("i-"+i+"_k-"+k+"_b");
+                
+                Statement nextTestStatement1 = vf.createStatement(nextRestBNode, RDF.FIRST, vf.createLiteral("literal: i-"+i+"_k-"+k));
+                this.testGraph.add(nextTestStatement1);
+                
+                // Fork the list in two
+                Statement nextTestStatement2 = vf.createStatement(nextRestBNode, RDF.REST, nextTreeBNode1);
+                this.testGraph.add(nextTestStatement2);
+                Statement nextTestStatement3 = vf.createStatement(nextRestBNode, RDF.REST, nextTreeBNode2);
+                this.testGraph.add(nextTestStatement3);
+
+                // Generate a terminating element for one of the arms
+                Statement nextTestNilStatement1 = vf.createStatement(nextTreeBNode2, RDF.FIRST, vf.createLiteral("terminating i-"+i+"_k-"+k+"_b"));
+                this.testGraph.add(nextTestNilStatement1);
+                
+                Statement nextTestNilStatement2 = vf.createStatement(nextTreeBNode2, RDF.REST, RDF.NIL);
+                this.testGraph.add(nextTestNilStatement2);
+            
+                if(k == kCount-1)
+                {
+                    Statement nextTestNilStatement3 = vf.createStatement(nextTreeBNode1, RDF.FIRST, vf.createLiteral("terminating i-"+i+"_k-"+k+"_a"));
+                    this.testGraph.add(nextTestNilStatement3);
+                    
+                    Statement nextTestNilStatement4 = vf.createStatement(nextTreeBNode1, RDF.REST, RDF.NIL);
+                    this.testGraph.add(nextTestNilStatement4);
+                }
+                else
+                {
+                    // branch others off the first one
+                    nextRestBNode = nextTreeBNode1;
+                }                    
+            }
+            heads.add(nextHeadBNode);
+        }
+        
+        int expectedGraphCount = (
+                // 5 statements for each i for each k
+                (iCount*kCount*5)+
+                // 2 terminating statements for each i
+                        (iCount*2)
+                );
+        log.info("expectedGraphCount="+expectedGraphCount);
+        log.info("this.testGraph.size()="+this.testGraph.size());
+        Assert.assertEquals(expectedGraphCount, this.testGraph.size());
+        
+        log.info("start");
+        try
+        {
+            final Collection<List<Value>> results = this.testRdfListUtilNoChecksOrRecursion.getLists(heads, this.testGraph);
+            Assert.fail("Expected exception not found");
+        }
+        catch(Exception ex)
+        {
+            Assert.assertTrue(ex.getMessage().contains("List was too long, maximum is"));
+        }
+        finally
+        {
+            log.info("end");
+        }
     }
 
     @Test
@@ -1545,7 +1776,7 @@ public class RdfListUtilTest
         try
         {
             @SuppressWarnings("unused")
-            final List<Value> results = RdfListUtil.getList(this.testListHeadBNode1, this.testGraph);
+            final List<Value> results = this.testRdfListUtilDefaults.getList(this.testListHeadBNode1, this.testGraph);
             Assert.fail("Did not find expected exception");
         }
         catch(final RuntimeException rex)
@@ -1579,7 +1810,7 @@ public class RdfListUtilTest
         try
         {
             @SuppressWarnings("unused")
-            final List<Value> results = RdfListUtil.getList(this.testListHeadBNode1, this.testGraph);
+            final List<Value> results = this.testRdfListUtilDefaults.getList(this.testListHeadBNode1, this.testGraph);
 
             Assert.assertEquals("Returned results from an invalid list structure", 0, results.size());
             Assert.fail("Did not find expected exception");
@@ -1623,7 +1854,7 @@ public class RdfListUtilTest
         try
         {
             @SuppressWarnings("unused")
-            final List<Value> results = RdfListUtil.getList(this.testListHeadBNode1, this.testGraph);
+            final List<Value> results = this.testRdfListUtilDefaults.getList(this.testListHeadBNode1, this.testGraph);
 
             Assert.assertEquals("Returned results from an invalid list structure", 0, results.size());
             Assert.fail("Did not find expected exception");


### PR DESCRIPTION
RdfListUtil is now a non-static class.

One test has been added for the error checking turned off, and one test has been added for the useIterativeOnError setting turned off.

There are two constructors, one for the defaults, and one that requires all three boolean settings.

Instances of the class are guaranteed to be threadsafe, as the settings variables are final and the class was previously threadsafe in its static design.
