### PR TITLE
bump sesame to 2.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
 	<properties>
 		<sesametools.version>1.7-SNAPSHOT</sesametools.version>
-		<sesame.version>2.6.3</sesame.version>
+		<sesame.version>2.6.4</sesame.version>
 		<slf4j.version>1.6.4</slf4j.version>
 		<junit.version>4.10</junit.version>
 		<restlet.version>2.1-RC3</restlet.version>


### PR DESCRIPTION
Bump to sesame to get latest fixes and compliance with latest SPARQL 1.1 draft

http://www.openrdf.org/issues/secure/ReleaseNote.jspa?projectId=10000&styleName=Html&version=10670

It includes a fix for a SPARQL 1.1 Update bug that I encountered while developing the URI Translator module, http://www.openrdf.org/issues/browse/SES-930
