### PR TITLE
Fix GraphResource REST endpoint

### DIFF
--- a/linked-data-server/src/main/java/net/fortytwo/sesametools/ldserver/GraphResource.java
+++ b/linked-data-server/src/main/java/net/fortytwo/sesametools/ldserver/GraphResource.java
@@ -10,6 +10,7 @@ import org.openrdf.sail.SailConnection;
 import org.openrdf.sail.SailException;
 import org.restlet.data.MediaType;
 import org.restlet.representation.Representation;
+import org.restlet.representation.Variant;
 import org.restlet.resource.Get;
 import org.restlet.resource.ServerResource;
 
@@ -43,8 +44,9 @@ public class GraphResource extends ServerResource {
         sail = LinkedDataServer.getInstance().getSail();
     }
 
+    @Override
     @Get
-    private Representation representInformationResource(final Representation entity) {
+    public Representation get(final Variant entity) {
         MediaType type = entity.getMediaType();
         RDFFormat format = RDFMediaTypes.findRdfFormat(type);
         selfURI = this.getRequest().getResourceRef().toString();


### PR DESCRIPTION
The GraphResource class was not working for for me... running the _DemoApp.class_ and `wget --header="Accept: application/x-trig" http://localhost:8001/graph/demoGraph` Tests first created an NPE for me and then a HTTP 405 code method not allowed. I fixed both in two separate commits.

Best!

Roland.
