### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/common/src/main/java/net/fortytwo/sesametools/Formatting.java
+++ b/common/src/main/java/net/fortytwo/sesametools/Formatting.java
@@ -8,6 +8,10 @@ package net.fortytwo.sesametools;
  * @author Joshua Shinavier (http://fortytwo.net)
  */
 public class Formatting {
+    
+    private Formatting() {
+        
+    }
 
     private static final int
             FOUR = 4,

--- a/common/src/main/java/net/fortytwo/sesametools/SesameTools.java
+++ b/common/src/main/java/net/fortytwo/sesametools/SesameTools.java
@@ -23,6 +23,10 @@ public class SesameTools {
             throw new ExceptionInInitializerError(e);
         }
     }
+    
+    private SesameTools() {
+        
+    }
 
     public static Properties getProperties() {
         return PROPERTIES;

--- a/deduplication-sail/src/main/java/net/fortytwo/sesametools/deduplication/DuplicateStatementFinder.java
+++ b/deduplication-sail/src/main/java/net/fortytwo/sesametools/deduplication/DuplicateStatementFinder.java
@@ -16,6 +16,10 @@ import java.util.Set;
  */
 public class DuplicateStatementFinder {
     private static final ValueFactory valueFactory = SimpleValueFactory.getInstance();
+    
+    private DuplicateStatementFinder() {
+        
+    }
 
     public static Set<Statement> findDuplicateStatements(final SailConnection sc) throws SailException {
         boolean includeInferred = false;

--- a/linked-data-server/src/main/java/net/fortytwo/sesametools/ldserver/RDFMediaTypes.java
+++ b/linked-data-server/src/main/java/net/fortytwo/sesametools/ldserver/RDFMediaTypes.java
@@ -39,6 +39,10 @@ public class RDFMediaTypes {
             RDF_VARIANTS.add(v);
         }
     }
+    
+    private RDFMediaTypes() {
+        
+    }
 
     public static List<Variant> getRDFVariants() {
         return RDF_VARIANTS;

--- a/uri-translator/src/main/java/net/fortytwo/sesametools/URITranslator.java
+++ b/uri-translator/src/main/java/net/fortytwo/sesametools/URITranslator.java
@@ -24,6 +24,10 @@ import java.util.List;
  */
 public class URITranslator {
     private final static Logger logger = LoggerFactory.getLogger(URITranslator.class);
+    
+    private URITranslator() {
+        
+    }
 
     /**
      * Maps IRIs for all triples in the given contexts in the given repository, between the input


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed