### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/common/src/main/java/net/fortytwo/sesametools/RdfListUtil.java
+++ b/common/src/main/java/net/fortytwo/sesametools/RdfListUtil.java
@@ -179,7 +179,7 @@ public class RdfListUtil {
 
         final Resource aHead = valueFactory.createBNode();
 
-        if (nextValues.size() > 0) {
+        if (!nextValues.isEmpty()) {
             graphToAddTo.add(subject, predicate, aHead, contexts);
         }
 
@@ -459,7 +459,7 @@ public class RdfListUtil {
                 }
             }
 
-            if (nextResult.size() > 0) {
+            if (!nextResult.isEmpty()) {
                 results.add(nextResult);
             }
         }

--- a/common/src/main/java/net/fortytwo/sesametools/SailWriter.java
+++ b/common/src/main/java/net/fortytwo/sesametools/SailWriter.java
@@ -30,7 +30,7 @@ public class SailWriter implements RDFHandler {
         this.action = action;
     }
 
-    public void finalize() throws Throwable {
+    protected void finalize() throws Throwable {
         super.finalize();
 
         if (null != sailConnection) {

--- a/constrained-sail/src/main/java/net/fortytwo/sesametools/constrained/ConstrainedSail.java
+++ b/constrained-sail/src/main/java/net/fortytwo/sesametools/constrained/ConstrainedSail.java
@@ -91,7 +91,7 @@ public class ConstrainedSail extends SailWrapper {
      */
     public boolean isWritable() throws SailException {
         return getBaseSail().isWritable()
-                && (writableSet.getNamedGraphs().size() > 0);  // TODO: OR the default analysis is writable
+                && (!writableSet.getNamedGraphs().isEmpty());  // TODO: OR the default analysis is writable
     }
 
     public void shutDown() throws SailException {

--- a/constrained-sail/src/main/java/net/fortytwo/sesametools/constrained/ConstrainedSailConnection.java
+++ b/constrained-sail/src/main/java/net/fortytwo/sesametools/constrained/ConstrainedSailConnection.java
@@ -302,7 +302,7 @@ public class ConstrainedSailConnection extends SailConnectionWrapper {
                     }
                 }
 
-                if (0 < toRemove.size()) {
+                if (!toRemove.isEmpty()) {
                     Resource[] ctxArray = new Resource[toRemove.size()];
                     toRemove.toArray(ctxArray);
                     super.removeStatements(subj, pred, obj, ctxArray);

--- a/rdf-transaction-sail/src/main/java/net/fortytwo/sesametools/rdftransaction/RDFTransactionSailConnection.java
+++ b/rdf-transaction-sail/src/main/java/net/fortytwo/sesametools/rdftransaction/RDFTransactionSailConnection.java
@@ -59,7 +59,7 @@ public class RDFTransactionSailConnection extends SailConnectionWrapper {
     }
 
     private void commitAll() throws SailException {
-        if (0 < buffer.size()) {
+        if (!buffer.isEmpty()) {
             sail.handleTransaction(buffer);
         }
 

--- a/uri-translator/src/main/java/net/fortytwo/sesametools/URITranslator.java
+++ b/uri-translator/src/main/java/net/fortytwo/sesametools/URITranslator.java
@@ -157,7 +157,7 @@ public class URITranslator {
 
             // add a single empty with clause if they didn't include any IRI resources as contexts
             // to make the rest of the code simpler
-            if (withClauses.size() == 0) {
+            if (withClauses.isEmpty()) {
                 withClauses.add("");
             }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1174 - "Object.finalize()" should remain protected (versus public) when overriding. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1174 

Please let me know if you have any questions.

Faisal Hameed