### PR TITLE
Multiple code quality fix-3

### DIFF
--- a/common/src/main/java/net/fortytwo/sesametools/SingleContextSailConnection.java
+++ b/common/src/main/java/net/fortytwo/sesametools/SingleContextSailConnection.java
@@ -198,7 +198,7 @@ class SingleContextSailConnection extends AbstractSailConnection {
         }
 
         public boolean hasNext() throws SailException {
-            return (null != nextContext);
+            return null != nextContext;
         }
 
         public Resource next() throws SailException {

--- a/constrained-sail/src/main/java/net/fortytwo/sesametools/constrained/ConstrainedSailConnection.java
+++ b/constrained-sail/src/main/java/net/fortytwo/sesametools/constrained/ConstrainedSailConnection.java
@@ -228,7 +228,7 @@ public class ConstrainedSailConnection extends SailConnectionWrapper {
 
     @Override
     public String getNamespace(String prefix) throws SailException {
-        return (namespacesAreReadable)
+        return namespacesAreReadable
                 ? super.getNamespace(prefix)
                 : null;
     }
@@ -236,7 +236,7 @@ public class ConstrainedSailConnection extends SailConnectionWrapper {
     @Override
     public CloseableIteration<? extends Namespace, SailException> getNamespaces()
             throws SailException {
-        return (namespacesAreReadable)
+        return namespacesAreReadable
                 ? super.getNamespaces()
                 : new EmptyCloseableIteration<Namespace, SailException>();
     }
@@ -338,7 +338,7 @@ public class ConstrainedSailConnection extends SailConnectionWrapper {
     @Override
     public long size(final Resource... contexts) throws SailException {
         if (0 == contexts.length) {
-            return (ALLOW_WILDCARD_SIZE)
+            return ALLOW_WILDCARD_SIZE
                     ? super.size()
                     : 0;
         } else {

--- a/replay-sail/src/main/java/net/fortytwo/sesametools/replay/RecorderSailConnection.java
+++ b/replay-sail/src/main/java/net/fortytwo/sesametools/replay/RecorderSailConnection.java
@@ -39,7 +39,7 @@ import java.util.Random;
  * @author Joshua Shinavier (http://fortytwo.net).
  */
 public class RecorderSailConnection extends AbstractSailConnection {
-    private final String id = "" + new Random().nextInt(0xFFFF);
+    private final String id = Integer.toString(new Random().nextInt(0xFFFF));
     private final Handler<SailConnectionCall, SailException> queryHandler;
     private final SailConnection baseSailConnection;
     private final ReplayConfiguration config;

--- a/sesamize/src/main/java/net/fortytwo/sesametools/sesamize/Sesamize.java
+++ b/sesamize/src/main/java/net/fortytwo/sesametools/sesamize/Sesamize.java
@@ -205,7 +205,7 @@ public class Sesamize {
 
         RDFWriter writer = Rio.createWriter(outputFormat, os);
         writer.startRDF();
-        for (long l = 0l; l < totalTriples; l++) {
+        for (long l = 0L; l < totalTriples; l++) {
             Statement st = rvf.randomStatement();
             writer.handleStatement(st);
         }

--- a/uri-translator/src/main/java/net/fortytwo/sesametools/URITranslator.java
+++ b/uri-translator/src/main/java/net/fortytwo/sesametools/URITranslator.java
@@ -182,7 +182,7 @@ public class URITranslator {
                         objectTemplateWhereBuilder.append("bind(iri(concat(\"");
                         objectTemplateWhereBuilder.append(outputUriPrefix);
                         objectTemplateWhereBuilder.append("\", encode_for_uri(substr(str(?objectUri), ");
-                        objectTemplateWhereBuilder.append((inputUriPrefix.length() + 1));
+                        objectTemplateWhereBuilder.append(inputUriPrefix.length() + 1);
                         objectTemplateWhereBuilder.append(")))) AS ?normalisedObjectUri) ");
                     } else {
                         // the following should be more efficient on large queries for exact matching,
@@ -242,7 +242,7 @@ public class URITranslator {
                         subjectTemplateWhereBuilder.append("bind(iri(concat(\"");
                         subjectTemplateWhereBuilder.append(outputUriPrefix);
                         subjectTemplateWhereBuilder.append("\", encode_for_uri(substr(str(?subjectUri), ");
-                        subjectTemplateWhereBuilder.append((inputUriPrefix.length() + 1));
+                        subjectTemplateWhereBuilder.append(inputUriPrefix.length() + 1);
                         subjectTemplateWhereBuilder.append(")))) AS ?normalisedSubjectUri) ");
                     } else {
                         // the following should be more efficient on large queries for exact matching,
@@ -300,7 +300,7 @@ public class URITranslator {
                         predicateTemplateWhereBuilder.append("bind(iri(concat(\"");
                         predicateTemplateWhereBuilder.append(outputUriPrefix);
                         predicateTemplateWhereBuilder.append("\", encode_for_uri(substr(str(?predicateUri), ");
-                        predicateTemplateWhereBuilder.append((inputUriPrefix.length() + 1));
+                        predicateTemplateWhereBuilder.append(inputUriPrefix.length() + 1);
                         predicateTemplateWhereBuilder.append(")))) AS ?normalisedPredicateUri) ");
                     } else {
                         // the following should be more efficient on large queries for exact matching,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2131- Primitives should not be boxed just for "String" conversion.
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed